### PR TITLE
updates to recent changes in scalameta/scalahost

### DIFF
--- a/tests/src/test/scala/meta/interpreter/internal/test/BasicInterpretationSpec.scala
+++ b/tests/src/test/scala/meta/interpreter/internal/test/BasicInterpretationSpec.scala
@@ -29,8 +29,6 @@ class BasicInterpretationSpec extends FlatSpec with ShouldMatchers {
   def interpret(expression: String, classes: List[String] = Nil)(implicit c: StandaloneContext): Any =
     Interpreter.eval(metaExpression(expression))
 
-  import scala.meta._
-  import scala.meta.internal.hosts.scalac.Scalahost
   val options = "-cp " + System.getProperty("sbt.paths.tests.classpath")
   implicit val c = Scalahost.mkStandaloneContext(options)
 

--- a/tests/src/test/scala/meta/interpreter/internal/test/RealWorldExamplesSuite.scala
+++ b/tests/src/test/scala/meta/interpreter/internal/test/RealWorldExamplesSuite.scala
@@ -6,7 +6,6 @@ import scala.meta.eval._
 import scala.meta.dialects.Scala211
 import scala.meta._
 import scala.meta.internal.hosts.scalac.contexts.StandaloneContext
-import scala.meta.internal.hosts.scalac.Scalahost
 import scala.reflect.{ ClassTag, classTag }
 import scala.meta.internal.{ ast => m }
 


### PR DESCRIPTION
scala.meta.internal.hosts.scalac.Scalahost has been moved to scala.meta.Scalahost,
so it's no longer necessary to explicitly import it as long as there's
a wildcard import from scala.meta in scope.